### PR TITLE
Potential fix for code scanning alert no. 1: Insecure randomness

### DIFF
--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -7,6 +7,7 @@ import type {
 } from 'ai';
 import { type ClassValue, clsx } from 'clsx';
 import { twMerge } from 'tailwind-merge';
+import { randomBytes } from 'crypto';
 
 import type { Message as DBMessage, Document } from '@/lib/db/schema';
 
@@ -45,7 +46,7 @@ export function getLocalStorage(key: string) {
 
 export function generateUUID(): string {
   return 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, (c) => {
-    const r = (Math.random() * 16) | 0;
+    const r = randomBytes(1)[0] % 16;
     const v = c === 'x' ? r : (r & 0x3) | 0x8;
     return v.toString(16);
   });


### PR DESCRIPTION
Potential fix for [https://github.com/ridwaanhall/Neon-AI/security/code-scanning/1](https://github.com/ridwaanhall/Neon-AI/security/code-scanning/1)

To fix the problem, we need to replace the use of `Math.random()` in the `generateUUID` function with a cryptographically secure random number generator. For Node.js, we can use the `crypto` module's `randomBytes` function to generate secure random values. This will ensure that the UUIDs generated are not predictable.

1. Import the `crypto` module in `lib/utils.ts`.
2. Modify the `generateUUID` function to use `crypto.randomBytes` instead of `Math.random()`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
